### PR TITLE
Edit "envrunner-base" to START script

### DIFF
--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -33,7 +33,7 @@ ENVRUNNER = """
 call %~dp0%activate {0}
 echo # run in conda environment "%CONDA_DEFAULT_ENV%":
 echo # %*
-%*
+start %*
 """.format(conda_env)
 
 _WSHELL = win32com.client.Dispatch("Wscript.Shell")


### PR DESCRIPTION
In the current state the cmd which opens when I click the shortcut on the desktop stays open. With this edit in place the cmd opens briefly and is then closed after calling the script as intended.